### PR TITLE
fix evaluation of multi-type

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,7 @@
 * `Evaluator.finalizeInputValue` loads file contents from remote file source if file does not exist locally
 * `CwlType.coerceTo` now returns both the coerced-to type and value
 * Added `CwlType.CwlGenericRecord`, which is coercible to either `CwlInputRecord` or `CwlOutputRecord`
+* Fixes evaluation of values with multiple possible types
 
 ## 0.7.4 (2021-01-05)
 


### PR DESCRIPTION
This is motivated by a case such as `evaluate(FloatValue(1.5), CwlMulti(CwlInt, CwlFloat))` - the result would be `(CwlInt, FloatValue(1.5))` because `CwlInt` is the first type in the list to which `FloatValue` is coercible, even though `1.5` is not actually coercible to `CwlInt` (because it is not an integral value).

The fix evaluates the value using all of the types and then collapses the result. If there is a single value, then that is returned, otherwise a string is preferred since it is is coercible to the most other types, otherwise the first value is chosen (somewhat arbitrarily).