### PR TITLE
APPS-1111 Fix default hints classnames

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## in develop
 
-* ..
+* Fixes CWL default requirement classnames `NetworkAccess`, `WorkReuse` and `ToolTimeLimit` so the corresponding hints can be recognized by dxCompiler (instead of being defined as GenericHints which are not interpreted during compilation).  
 
 ## 0.8.0 (2022-02-08)
 

--- a/src/main/scala/dx/cwl/Evaluator.scala
+++ b/src/main/scala/dx/cwl/Evaluator.scala
@@ -435,25 +435,25 @@ object Runtime {
              maxTmpdirSize: Option[Long] = None): Runtime = {
     val actualCores = JavaRuntime.getRuntime.availableProcessors()
     if (minCores.exists(_ > actualCores)) {
-      throw new Exception(s"avaiable cores ${actualCores} is less than min cores ${minCores}")
+      throw new Exception(s"available cores ${actualCores} is less than min cores ${minCores}")
     }
     val cores = maxCores.map(Math.min(_, actualCores)).getOrElse(actualCores)
     val actualRam = totalMemorySize
     if (minRam.exists(_ > actualRam)) {
-      throw new Exception(s"avaiable ram ${actualRam} is less than min ram ${minRam}")
+      throw new Exception(s"available ram ${actualRam} is less than min ram ${minRam}")
     }
     val ram = maxRam.map(Math.min(_, actualRam)).getOrElse(actualRam)
     val actualOutdirSize = outdir.getRoot.toFile.getFreeSpace
     if (minOutdirSize.exists(_ > actualOutdirSize)) {
       throw new Exception(
-          s"avaiable outdir size ${actualOutdirSize} is less than min outdir size ${minOutdirSize}"
+          s"available outdir size ${actualOutdirSize} is less than min outdir size ${minOutdirSize}"
       )
     }
     val outdirSize = maxOutdirSize.map(Math.min(_, actualOutdirSize)).getOrElse(actualOutdirSize)
     val actualTmpdirSize = tmpdir.getRoot.toFile.getFreeSpace
     if (minTmpdirSize.exists(_ > actualTmpdirSize)) {
       throw new Exception(
-          s"avaiable tmpdir size ${actualTmpdirSize} is less than min tmpdir size ${minTmpdirSize}"
+          s"available tmpdir size ${actualTmpdirSize} is less than min tmpdir size ${minTmpdirSize}"
       )
     }
     val tmpdirSize = maxTmpdirSize.map(Math.min(_, actualTmpdirSize)).getOrElse(actualTmpdirSize)

--- a/src/main/scala/dx/cwl/Hint.scala
+++ b/src/main/scala/dx/cwl/Hint.scala
@@ -51,6 +51,7 @@ case class GenericHint(attributes: Map[String, Any]) extends Hint
 /**
   * One of the requirements defined in the CWL spec.
   * https://www.commonwl.org/v1.2/CommandLineTool.html#InlineJavascriptRequirement
+  * https://www.commonwl.org/v1.2/Workflow.html#InlineJavascriptRequirement
   */
 sealed trait Requirement extends Hint
 

--- a/src/main/scala/dx/cwl/Hint.scala
+++ b/src/main/scala/dx/cwl/Hint.scala
@@ -66,10 +66,10 @@ object Requirement {
       case req: EnvVarRequirementImpl             => EnvVarRequirement(req, schemaDefs)
       case _: ShellCommandRequirementImpl         => ShellCommandRequirement
       case req: ResourceRequirementImpl           => ResourceRequirement(req, schemaDefs)
-      case req: WorkReuseImpl                     => WorkReuseRequirement(req, schemaDefs)
-      case req: NetworkAccessImpl                 => NetworkAccessRequirement(req, schemaDefs)
+      case req: WorkReuseImpl                     => WorkReuse(req, schemaDefs)
+      case req: NetworkAccessImpl                 => NetworkAccess(req, schemaDefs)
       case req: InplaceUpdateRequirementImpl      => InplaceUpdateRequirement(req)
-      case req: ToolTimeLimitImpl                 => ToolTimeLimitRequirement(req, schemaDefs)
+      case req: ToolTimeLimitImpl                 => ToolTimeLimit(req, schemaDefs)
       case _: SubworkflowFeatureRequirementImpl   => SubworkflowFeatureRequirement
       case _: ScatterFeatureRequirementImpl       => ScatterFeatureRequirement
       case _: MultipleInputFeatureRequirementImpl => MultipleInputFeatureRequirement
@@ -115,10 +115,10 @@ object Requirement {
       EnvVarRequirement,
       ShellCommandRequirement,
       ResourceRequirement,
-      WorkReuseRequirement,
-      NetworkAccessRequirement,
+      WorkReuse,
+      NetworkAccess,
       InplaceUpdateRequirement,
-      ToolTimeLimitRequirement
+      ToolTimeLimit
   ).map(schema => schema.className -> schema).toMap
 
   def apply(hint: Map[String, Any],
@@ -550,28 +550,27 @@ object ResourceRequirement extends HintSchema {
   )
 }
 
-case class WorkReuseRequirement(enable: CwlValue) extends Requirement
+case class WorkReuse(enable: CwlValue) extends Requirement
 
-object WorkReuseRequirement extends HintSchema {
-  def apply(req: WorkReuseImpl, schemaDefs: Map[String, CwlSchema]): WorkReuseRequirement = {
-    WorkReuseRequirement(CwlValue(req.getEnableReuse, schemaDefs))
+object WorkReuse extends HintSchema {
+  def apply(req: WorkReuseImpl, schemaDefs: Map[String, CwlSchema]): WorkReuse = {
+    WorkReuse(CwlValue(req.getEnableReuse, schemaDefs))
   }
 
   override def apply(hint: Map[String, Any], schemaDefs: Map[String, CwlSchema]): Hint = {
-    WorkReuseRequirement(enable = CwlValue(hint("enableReuse"), schemaDefs))
+    WorkReuse(enable = CwlValue(hint("enableReuse"), schemaDefs))
   }
 }
 
-case class NetworkAccessRequirement(allow: CwlValue) extends Requirement
+case class NetworkAccess(allow: CwlValue) extends Requirement
 
-object NetworkAccessRequirement extends HintSchema {
-  def apply(req: NetworkAccessImpl,
-            schemaDefs: Map[String, CwlSchema]): NetworkAccessRequirement = {
-    NetworkAccessRequirement(CwlValue(req.getNetworkAccess, schemaDefs))
+object NetworkAccess extends HintSchema {
+  def apply(req: NetworkAccessImpl, schemaDefs: Map[String, CwlSchema]): NetworkAccess = {
+    NetworkAccess(CwlValue(req.getNetworkAccess, schemaDefs))
   }
 
   override def apply(hint: Map[String, Any], schemaDefs: Map[String, CwlSchema]): Hint = {
-    NetworkAccessRequirement(allow = CwlValue(hint("networkAccess"), schemaDefs))
+    NetworkAccess(allow = CwlValue(hint("networkAccess"), schemaDefs))
   }
 }
 
@@ -590,16 +589,15 @@ object InplaceUpdateRequirement extends HintSchema {
   }
 }
 
-case class ToolTimeLimitRequirement(timeLimit: CwlValue) extends Requirement
+case class ToolTimeLimit(timeLimit: CwlValue) extends Requirement
 
-object ToolTimeLimitRequirement extends HintSchema {
-  def apply(req: ToolTimeLimitImpl,
-            schemaDefs: Map[String, CwlSchema]): ToolTimeLimitRequirement = {
-    ToolTimeLimitRequirement(CwlValue(req.getTimelimit, schemaDefs))
+object ToolTimeLimit extends HintSchema {
+  def apply(req: ToolTimeLimitImpl, schemaDefs: Map[String, CwlSchema]): ToolTimeLimit = {
+    ToolTimeLimit(CwlValue(req.getTimelimit, schemaDefs))
   }
 
   override def apply(hint: Map[String, Any], schemaDefs: Map[String, CwlSchema]): Hint = {
-    ToolTimeLimitRequirement(timeLimit = CwlValue(hint("timelimit"), schemaDefs))
+    ToolTimeLimit(timeLimit = CwlValue(hint("timelimit"), schemaDefs))
   }
 }
 


### PR DESCRIPTION
This PR is to fix the requirement class names defined in cwl v1.2 schema.
https://www.commonwl.org/v1.2/cwl.ttl#ProcessRequirement
Previously when giving as hints, these requirements are recognized as GenericHints since the class names are different, but dxCompiler will not interpret them into runtime requirements. By fixing the names now dxCompiler could process these hints properly.
https://www.commonwl.org/v1.2/CommandLineTool.html#WorkReuse
https://www.commonwl.org/v1.2/CommandLineTool.html#NetworkAccess
https://www.commonwl.org/v1.2/CommandLineTool.html#ToolTimeLimit