### PR TITLE
APPS-1280-fix-enum-symbol-parsing

### DIFF
--- a/src/main/scala/dx/cwl/CwlType.scala
+++ b/src/main/scala/dx/cwl/CwlType.scala
@@ -28,8 +28,7 @@ import org.w3id.cwl.cwl1_2.{
   SecondaryFileSchemaImpl,
   stderr => CWLStderr,
   stdin => CWLStdin,
-  stdout => CWLStdout,
-  utils
+  stdout => CWLStdout
 }
 
 import scala.annotation.tailrec
@@ -893,7 +892,10 @@ case class CwlEnum(symbols: Vector[String],
     * symbols may be fully namespaced - this method returns just name part (after the last '/').
     */
   lazy val symbolNames: Vector[String] = {
-    symbols.map(utils.Uris.shortname(_))
+    symbols.map {
+      case CwlEnum.symbolRegex(_, name) => name
+      case other                        => throw new Exception(s"invalid symbol ${other}")
+    }
   }
 
   override protected def canBeCoercedTo(targetType: CwlType): Boolean = {
@@ -913,6 +915,8 @@ case class CwlEnum(symbols: Vector[String],
 }
 
 object CwlEnum {
+  val symbolRegex: Regex = "(.+/)?(.+)".r
+
   def apply(schema: EnumSchema, schemaDefs: Map[String, CwlSchema]): CwlEnum = {
     val (name, label, doc) = schema match {
       case schema: InputEnumSchema  => (schema.getName, schema.getLabel, schema.getDoc)

--- a/src/main/scala/dx/cwl/CwlType.scala
+++ b/src/main/scala/dx/cwl/CwlType.scala
@@ -34,6 +34,7 @@ import org.w3id.cwl.cwl1_2.{
 import scala.annotation.tailrec
 import scala.collection.immutable.{SeqMap, TreeSeqMap}
 import scala.jdk.CollectionConverters._
+import scala.util.matching.Regex
 
 /**
   * Marker trait for all CWL data types.

--- a/src/test/scala/dx/cwl/EvaluatorTest.scala
+++ b/src/test/scala/dx/cwl/EvaluatorTest.scala
@@ -132,6 +132,20 @@ class EvaluatorTest extends AnyWordSpec with Matchers {
                          ctx,
                          coerce = true) shouldBe (CwlInt, IntValue(1))
     }
+
+    "coerce string to enum symbol" in {
+      val ctx = EvaluatorContext(StringValue("TranscriptomeSAM GeneCounts"))
+      val targetType = CwlOptional(
+          CwlEnum(
+              Vector("STAR-1/quantMode/quantMode/TranscriptomeSAM",
+                     "STAR-1/quantMode/quantMode/GeneCounts",
+                     "STAR-1/quantMode/quantMode/TranscriptomeSAM GeneCounts")
+          )
+      )
+      evaluator
+        .evaluate(StringValue("$(self)"), targetType, ctx, coerce = true)
+        ._2 shouldBe StringValue("TranscriptomeSAM GeneCounts")
+    }
   }
 
   private case class SplitTest(s: String, expected: EcmaString)


### PR DESCRIPTION
This PR is use regex instead of symbolNames helper function in cwljava.