### PR TITLE
APPS-1225-add-file-object-metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ object EvalutatorExample {
 
 ## Requirements
 
-* JDK 8
+* JDK 11
 * Scala 2.13
 * sbt
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 # Change log
 
 ## in develop
-..
+
+* Added support for "metadata" field for input files in CWL under development (pending inclusion in CWL standard).
 
 ## 0.8.3 (2022-05-16)
 

--- a/src/main/scala/dx/cwl/CwlValue.scala
+++ b/src/main/scala/dx/cwl/CwlValue.scala
@@ -833,12 +833,20 @@ object PathValue {
     }
   }
 
+  def unwrapMap(jsValue: JsValue): String = {
+    jsValue match {
+      case v: JsObject => v.toString()
+      case _ =>
+        throw new Exception(s"expected map, not ${jsValue}")
+    }
+  }
+
   def unwrapLong(jsValue: JsValue): Long = {
     jsValue match {
       case JsNumber(n) => n.toLongExact
       case JsString(s) => s.toLong
       case _ =>
-        throw new Exception(s"expected string, not ${jsValue}")
+        throw new Exception(s"expected number or string number, not ${jsValue}")
     }
   }
 
@@ -983,7 +991,7 @@ object FileValue {
             },
             fields.get("format").map(PathValue.unwrapString),
             fields.get("contents").map(PathValue.unwrapString),
-            fields.get("metadata").map(_.prettyPrint)
+            fields.get("metadata").map(PathValue.unwrapMap)
         )
       case _ =>
         throw new Exception(s"invalid file value ${jsValue}")

--- a/src/main/scala/dx/cwl/CwlValue.scala
+++ b/src/main/scala/dx/cwl/CwlValue.scala
@@ -771,7 +771,9 @@ sealed trait PathValue extends PrimitiveValue with StringIndexable {
   override lazy val toJson: JsValue = {
     val fields = productElementNames.flatMap { key =>
       get(key) match {
-        case None        => None
+        case None => None
+        case Some(metadata: StringValue) if key == "metadata" =>
+          Some(key -> metadata.toString.parseJson)
         case Some(value) => Some(key -> value.toJson)
       }
     }.toMap
@@ -858,7 +860,8 @@ case class FileValue(location: Option[String] = None,
                      size: Option[Long] = None,
                      secondaryFiles: Vector[PathValue] = Vector.empty,
                      format: Option[String] = None,
-                     contents: Option[String] = None)
+                     contents: Option[String] = None,
+                     metadata: Option[String] = None)
     extends PathValue {
   override val cwlType: CwlPath = CwlFile
   private val keys: Set[String] = Set("location",
@@ -871,7 +874,8 @@ case class FileValue(location: Option[String] = None,
                                       "size",
                                       "secondaryFiles",
                                       "format",
-                                      "contents")
+                                      "contents",
+                                      "metadata")
 
   override def contains(key: String): Boolean = {
     keys.contains(key)
@@ -890,6 +894,7 @@ case class FileValue(location: Option[String] = None,
       case "secondaryFiles" => Some(ArrayValue(secondaryFiles))
       case "format"         => format.map(StringValue(_))
       case "contents"       => contents.map(StringValue(_))
+      case "metadata"       => metadata.map(StringValue(_))
       case _ =>
         throw new Exception(s"invalid File property ${key}")
     }
@@ -915,7 +920,8 @@ object FileValue {
         },
         translateOptionalArray(file.getSecondaryFiles).map(PathValue.apply),
         translateOptional(file.getFormat),
-        translateOptional(file.getContents)
+        translateOptional(file.getContents),
+        None
     )
   }
 
@@ -941,7 +947,8 @@ object FileValue {
             throw new Exception(s"unexpected secondaryFiles value ${other}")
         },
         translateOptionalString(map.get("format")),
-        translateOptionalString(map.get("contents"))
+        translateOptionalString(map.get("contents")),
+        translateOptionalString(map.get("metadata"))
     )
   }
 
@@ -975,7 +982,8 @@ object FileValue {
                 throw new Exception(s"invalid secondaryFiles value ${other}")
             },
             fields.get("format").map(PathValue.unwrapString),
-            fields.get("contents").map(PathValue.unwrapString)
+            fields.get("contents").map(PathValue.unwrapString),
+            fields.get("metadata").map(_.prettyPrint)
         )
       case _ =>
         throw new Exception(s"invalid file value ${jsValue}")

--- a/src/main/scala/dx/cwl/Evaluator.scala
+++ b/src/main/scala/dx/cwl/Evaluator.scala
@@ -618,7 +618,8 @@ object EvaluatorContext {
               newSize,
               newSecondaryFiles,
               f.format,
-              newContents
+              newContents,
+              f.metadata
           )
         case d: DirectoryValue =>
           val newListing = if (d.listing.isEmpty && recurseListings) {

--- a/src/test/scala/dx/cwl/CwlValueTest.scala
+++ b/src/test/scala/dx/cwl/CwlValueTest.scala
@@ -27,6 +27,29 @@ class CwlValueTest extends AnyFlatSpec with Matchers {
     v shouldBe IntValue(5)
   }
 
+  it should "deserialize the input JSON to File " in {
+    val inputJson = JsObject(
+        fields = Map(
+            "contents" -> JsString("test"),
+            "metadata" -> JsObject(
+                fields = Map(
+                    "int_meta" -> JsNumber("1"),
+                    "str_meta" -> JsString("test"),
+                    "bool_meta" -> JsBoolean(true),
+                    "arr_meta" -> JsArray(
+                        Vector(JsString("elem1"), JsString("elem2"), JsString("elem3"))
+                    )
+                )
+            )
+        )
+    )
+
+    val (t, v) = CwlValue.deserialize(inputJson, CwlFile, Map.empty)
+    t shouldBe CwlFile
+    v shouldBe FileValue(contents = Some("test"),
+                         metadata = inputJson.fields.get("metadata").map(_.prettyPrint))
+  }
+
   it should "coerce null to optional" in {
     val t = CwlOptional(CwlString)
     NullValue.coercibleTo(t) shouldBe true

--- a/src/test/scala/dx/cwl/CwlValueTest.scala
+++ b/src/test/scala/dx/cwl/CwlValueTest.scala
@@ -27,7 +27,7 @@ class CwlValueTest extends AnyFlatSpec with Matchers {
     v shouldBe IntValue(5)
   }
 
-  it should "deserialize the input JSON to File " in {
+  it should "deserialize the input JSON to FileValue" in {
     val inputJson = JsObject(
         fields = Map(
             "contents" -> JsString("test"),
@@ -47,7 +47,33 @@ class CwlValueTest extends AnyFlatSpec with Matchers {
     val (t, v) = CwlValue.deserialize(inputJson, CwlFile, Map.empty)
     t shouldBe CwlFile
     v shouldBe FileValue(contents = Some("test"),
-                         metadata = inputJson.fields.get("metadata").map(_.prettyPrint))
+                         metadata = inputJson.fields.get("metadata").map(_.toString()))
+
+    val inputJson2 = JsObject(
+        fields = Map(
+            "contents" -> JsString("test2"),
+            "metadata" -> JsObject(
+                fields = Map.empty
+            )
+        )
+    )
+
+    val (t2, v2) = CwlValue.deserialize(inputJson2, CwlFile, Map.empty)
+    t2 shouldBe CwlFile
+    v2 shouldBe FileValue(contents = Some("test2"), metadata = Some("{}"))
+
+    val inputJson3 = JsObject(
+        fields = Map(
+            "contents" -> JsString("test3"),
+            "metadata" -> JsNull
+        )
+    )
+
+    val caught =
+      intercept[Exception] {
+        CwlValue.deserialize(inputJson3, CwlFile, Map.empty)
+      }
+    caught.getMessage shouldBe s"expected map, not null"
   }
 
   it should "coerce null to optional" in {


### PR DESCRIPTION
This PR is to add `metadata` field in the CWL File Object. It is not explicitly supported by CWL v1.2.0 standard, however, cwltool could parse it as a valid map, so users could couple some metadata along with the supplied File object, and propagate them to the Javascript expressions.

Full support of File metadata is expected later this year in CWL v1.2.1. This PR is a quick implementation of metadata that is used only on DNAnexus platform. 

The metadata field is stringified during compilation and then deserialized back to the JSON map in the execution env on the DNAnexus platform. 

The purpose of stringifying the metadata field is that:

- when translating each field its data type is fixed. For example, the File `location` field is expected to be a URI and the `size` is required to be an integer. But the metadata field will have no such limit, in other words, any JSON type might appear.

- Therefore, stringifying the whole metadata field can help safely pack all the metadata values in their original format, so later cwltool can properly process it when executing the source code.